### PR TITLE
Fix docs grammar

### DIFF
--- a/src/advanced/bash-completion.md
+++ b/src/advanced/bash-completion.md
@@ -8,8 +8,8 @@ order: 60
 Bashly comes with a built-in bash completions generator, provided by the
 [completely][completely] gem.
 
-By running `bashly add completions` command, you can add this functionality
-to your script in one of three ways:
+By running `bashly add completions`, you can add this functionality to your
+script in one of three ways:
 
 
 ==- `bashly add completions`

--- a/src/advanced/bash-completion.md
+++ b/src/advanced/bash-completion.md
@@ -5,10 +5,10 @@ order: 60
 
 # Bash Completion
 
-Bashly comes with built-in bash completions generator, provided by the
+Bashly comes with a built-in bash completions generator, provided by the
 [completely][completely] gem.
 
-By running `bashly add completions` commands, you can add this functionality
+By running `bashly add completions` command, you can add this functionality
 to your script in one of three ways:
 
 
@@ -91,7 +91,7 @@ these will be automatically added to the completions list as well.
 
 If you are using Oh-My-Zsh, bash completions should already be enabled,
 otherwise, you should enable completion by adding this to your `~/.zshrc`
-(if is it not already there):
+(if it is not already there):
 
 ```bash
 # Load completion functions

--- a/src/advanced/hooks.md
+++ b/src/advanced/hooks.md
@@ -23,7 +23,7 @@ Run `bashly add hooks` to create the hook files in your source directory.
 
 ## Alternatives
 
-These hooks should be considered last resort, for any functionality that is not 
+These hooks should be considered a last resort, for any functionality that is not
 covered by more native means.
 
 Below is a list of some related features that can

--- a/src/advanced/rendering.md
+++ b/src/advanced/rendering.md
@@ -11,7 +11,7 @@ Bashly is capable of rendering documentation for your script based on
 your `bashly.yml` configuration by using the `bashly render` command.
 
 This command can generate any kind of output using either templates that are 
-built in in Bashly (for example Markdown or man pages), or by using
+built into Bashly (for example Markdown or man pages), or by using
 any custom templates.
 
 ## Built-in templates
@@ -23,7 +23,7 @@ all templates, run:
 $ bashly render --list
 ```
 
-Some built in templates may have special optional features that let you 
+Some built-in templates may have special optional features that let you
 customize the output. Learn more about each template by running:
 
 ```bash

--- a/src/advanced/validations.md
+++ b/src/advanced/validations.md
@@ -10,7 +10,7 @@ arguments, and environment variables. This is how it works:
 
 1. In your bashly configuration file, arguments and flags (with arguments)
    may have a `validate: function_name` option.
-2. Whenever your run your script, it will look for a function with that name,
+2. Whenever you run your script, it will look for a function with that name,
    prefixed by `validate_` and will run it before allowing the user
    input to pass.
 3. If the function returns any string, it is considered an error. The

--- a/src/configuration/command.md
+++ b/src/configuration/command.md
@@ -164,7 +164,7 @@ The string to display when using `--version`.
 
 - Setting this to `true` on any command, will cause any **unrecognized**
   command line to be passed to this command.
-- Settings this to `force` will also execute this command (instead of showing
+- Setting this to `force` will also execute this command (instead of showing
   the root usage text) when executed without any arguments.
 
 [!button variant="primary" icon="code-review" text="Default Command Example"](https://github.com/DannyBen/bashly/tree/master/examples/command-default#readme) [!button variant="primary" icon="code-review" text="Forced Command Example"](https://github.com/DannyBen/bashly/tree/master/examples/command-default-force#readme)

--- a/src/usage/testing-your-scripts.md
+++ b/src/usage/testing-your-scripts.md
@@ -32,9 +32,9 @@ In cases where your scripts are more elaborate, or when you wish to ensure
 your scripts behave as expected, you can use any bash testing framework to test
 your scripts.
 
-One such lightweight framework, is
+One such lightweight framework is
 [Approvals.bash](https://github.com/dannyben/approvals.bash#readme), which lets
-you test any command in your script, and prompting you for interactive approval
+you test any command in your script and prompts you for interactive approval
 of its output. Whenever the output changes, you will be prompted again to approve it.
 
 A sample test script looks like this:


### PR DESCRIPTION
## Summary
- fix grammar in `bash-completion.md`
- fix typos in `rendering.md`
- fix typo in `validations.md`
- clarify hooks docs
- correct default command docs
- polish testing docs

## Testing
- `bash test/test.sh` *(fails: aspell not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750a664d14832c83b573617838bee9